### PR TITLE
fixes woosidebars post type recognition on post type archives

### DIFF
--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -448,7 +448,13 @@ class Woo_Conditions {
 	 */
 	public function is_post_type_archive () {
 		if ( is_post_type_archive() ) {
-			$this->conditions[] = 'post-type-archive-' . get_post_type();
+
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ){
+				$post_type = reset( $post_type );
+			}
+
+			$this->conditions[] = 'post-type-archive-' . $post_type;
 		}
 	} // End is_post_type_archive()
 


### PR DESCRIPTION
The sidebar was not showing up on the sensei message post type archive page. On further inspection I found that get_post_type() doesn't working as expected on the post type archives. This fix ensure that we always get the post type for the current post type archives page.
