### PR TITLE
Fix a Warning (Invalid argument in foreach) when there is no tags in the post

### DIFF
--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -392,7 +392,7 @@ class Woo_Conditions {
 			// Has Tag conditions.
 			$tags = get_the_tags( get_the_ID() );
 
-			if ( ! is_wp_error( $tags ) && ( 0 < count( $tags ) ) ) {
+			if ( ! is_wp_error( $tags ) && is_array( $tags ) && ( 0 < count( $tags ) ) ) {
 				foreach ( $tags as $k => $v ) {
 					$this->conditions[] = 'has-term-' . $v->term_id;
 				}


### PR DESCRIPTION
I made a small change after i saw this error in a website : "Warning: Invalid argument supplied for foreach() in
woosidebars/classes/class-woo-conditions.php on line 396"

This pull request resolve this issue : https://github.com/woothemes/woosidebars/issues/36