### PR TITLE
#38 Fix Notice Undefined index : templates in Conditions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** WooSidebars Changelog ***
 
-2013.04.15 - version 1.3.0
+2013.08.13 - version 1.3.1
+ * /classes/class-woo-conditions.php - Re-introduce add_post_meta() instead of update_post_meta() when saving conditions. Using update_post_meta() prevents multiple conditions from being saved.
+
+2013.08.12 - version 1.3.0
  * /assets/css/admin.css - Replace all instances of #woo-conditions with #woosidebars-conditions to match the renamed meta box. Add basic jQueryUI styling reset to prevent visual inconsistency when jQueryUI is loaded via a third-party plugin.
  * /assets/js/admin.js - Adjust the JavaScript logic to use the new "woosidebars-conditions" selector instead of "woo-conditions" for toggling advanced options on and off.
  * /classes/class-woo-conditions.php - Rename "woo-conditions" meta box to "woosidebars-conditions". Fixes display bug with the WPML "Multilingual Content Setup" meta box. Replaces all instances of &$this with $this. Introduces upper_limit property and woosidebars_upper_limit filter. Addresses logic for the "single" condition type.

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -670,11 +670,11 @@ class Woo_Conditions {
 			}
 		}
 
-		if ( isset( $_POST['conditions'] ) && ( count( $_POST['conditions'] ) > 0 ) ) {
+		if ( isset( $_POST['conditions'] ) && ( 0 < count( $_POST['conditions'] ) ) ) {
 			delete_post_meta( $post_id, '_condition' );
 
 			foreach ( $_POST['conditions'] as $k => $v ) {
-				update_post_meta( $post_id, '_condition', $v, false );
+				add_post_meta( $post_id, '_condition', $v, false );
 			}
 		}
 	} // End meta_box_save()

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -205,11 +205,11 @@ class Woo_Conditions {
 		}
 
 		// Page Templates
-		$conditions['templates'] = array();
-
 		$page_templates = get_page_templates();
 
 		if ( count( $page_templates ) > 0 ) {
+
+			$conditions['templates'] = array();
 
 			$conditions_headings['templates'] = __( 'Page Templates', 'woosidebars' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woothemes, mattyza
 Tags: widgets, sidebars, widget-areas
 Requires at least: 3.3
 Tested up to: 3.6.0
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -71,6 +71,9 @@ Looking to contribute code to this plugin? [Fork the repository over at GitHub](
 
 == Upgrade Notice ==
 
+= 1.3.1 =
+Bug fix to ensure multiple conditions save correctly.
+
 = 1.3.0 =
 Optimisation update.
 
@@ -84,6 +87,10 @@ Updated for WordPress 3.5+ compatibility. Adjusted "Advanced" tab logic. Fixed b
 Moved to WordPress.org. Woo! Added scope to methods and properties where missing.
 
 == Changelog ==
+
+= 1.3.1 =
+* 2013-08-13
+* Bug fix to ensure multiple conditions save correctly.
 
 = 1.3.0 =
 * 2013-08-12

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woothemes, mattyza
 Tags: widgets, sidebars, widget-areas
 Requires at least: 3.3
-Tested up to: 3.8.0
+Tested up to: 4.1.0
 Stable tag: 1.4.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woosidebars.php
+++ b/woosidebars.php
@@ -5,8 +5,8 @@
  * Description: Replace widget areas in your theme for specific pages, archives and other sections of WordPress.
  * Author: WooThemes
  * Author URI: http://woothemes.com/
- * Version: 1.3.0
- * Stable tag: 1.3.0
+ * Version: 1.3.1
+ * Stable tag: 1.3.1
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  */
 
@@ -22,6 +22,6 @@
 
  global $woosidebars;
  $woosidebars = new Woo_Sidebars( __FILE__ );
- $woosidebars->version = '1.3.0';
+ $woosidebars->version = '1.3.1';
  $woosidebars->init();
 ?>


### PR DESCRIPTION
I resolve the issue #38 which i can reproduce in four steps : 
1. Install latest Wordpress version
2. Activate a theme with no page template (example : twentyfifteen)
3. Download and activate Woosidebars
4. Go to Apparence > Widgets Areas > Add new

You can find a PHP notice in the conditions metabox : "Notice: Undefined index: templates in /.../wp-content/plugins/woosidebars/classes/class-woo-conditions.php on line 582"

It's because an empty array with 'templates' key is create before check if there is templates page in the theme. I just move this declaration, it's a minor change.

I test my change with a template page, no error.

